### PR TITLE
Fix 'animate: swipe' animation

### DIFF
--- a/swipe-navigation.js
+++ b/swipe-navigation.js
@@ -50,6 +50,10 @@ function swipeNavigation() {
     appLayout.addEventListener("touchend", handleTouchEnd, { passive: true });
   }
 
+  if (animate == "swipe") {
+    appLayout.style.overflow = "hidden";
+  }
+
   function handleTouchStart(event) {
     let ignored = [
       "APP-HEADER",


### PR DESCRIPTION
With Home Assistant Core 0.117.0 and Lovelace Swipe Navigation 1.2.7 the swipe animation is very buggy. It seems to zoom the viewport, especially for larger views. This is probably caused by enabling native zooming in 0.117.0 in combination with negative positioned viewports when doing the swipe animation.

This PR will fix this. I also tried to set and unset `overflow: hidden` before and after the animation, but that way it was still buggy when swiping fast through multiple views.
